### PR TITLE
Check for invalid Move with '--'

### DIFF
--- a/ChessEngine.py
+++ b/ChessEngine.py
@@ -792,6 +792,10 @@ class Move():
         self.endRC = self.endRow * 6 + self.endCol
 
         self.pieceMoved = board[self.startRC]
+        #check if piecedMoved is a valid figure
+        if(self.pieceMoved == "--"): 
+            raise ValueError('try moving a piece that is not on the board')
+
         self.pieceCaptured = board[self.endRC]
 
         self.moveID = self.startRow * 1000 + self.startCol * 100 + self.endRow * 10 + self.endCol


### PR DESCRIPTION
With this addition it raises an error if the agent try to move `'--'`

Fix for  #4 